### PR TITLE
Update AO Baking Example

### DIFF
--- a/example/aoBake.js
+++ b/example/aoBake.js
@@ -95,7 +95,6 @@ async function init() {
 		thickness: 1,
 		attenuationColor: 0xfaeef2,
 		attenuationDistance: 0.5,
-		roughness: 0.25,
 	} );
 
 	quad = new FullScreenQuad( new MeshBasicMaterial( {
@@ -222,11 +221,13 @@ function animate() {
 		aoMaterial.color.r *= 0.75;
 		aoMaterial.color.g *= 0.5;
 		aoMaterial.color.b *= 0.5;
+		aoMaterial.roughness = 0.25;
 
 	} else {
 
 		aoMaterial.transmission = 0;
 		aoMaterial.color.set( 0xffffff );
+		aoMaterial.roughness = 1;
 
 	}
 

--- a/example/aoBake.js
+++ b/example/aoBake.js
@@ -248,7 +248,6 @@ function animate() {
 
 		statusEl.innerText = `Samples: ${ totalSamples } of ${ MAX_SAMPLES }`;
 
-
 	}
 
 }

--- a/example/aoBake.js
+++ b/example/aoBake.js
@@ -7,13 +7,10 @@ import {
 	WebGLRenderTarget,
 	FloatType,
 	LinearSRGBColorSpace,
-	NearestMipMapNearestFilter,
-	NearestFilter,
 	RGBAFormat,
 	Group,
 	Box3,
 	Sphere,
-	MeshStandardMaterial,
 	MeshPhysicalMaterial
 } from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
@@ -69,8 +66,6 @@ async function init() {
 		type: FloatType,
 		colorSpace: LinearSRGBColorSpace,
 		generateMipmaps: true,
-		// minFilter: NearestMipMapNearestFilter,
-		// magFilter: NearestFilter,
 		format: RGBAFormat,
 	} );
 

--- a/example/aoBake.js
+++ b/example/aoBake.js
@@ -1,125 +1,27 @@
-import * as THREE from 'three';
+import {
+	WebGLRenderer,
+	PerspectiveCamera,
+	Scene,
+	PointLight,
+	AmbientLight,
+	WebGLRenderTarget,
+	FloatType,
+	LinearSRGBColorSpace,
+	NearestMipMapNearestFilter,
+	NearestFilter,
+	RGBAFormat,
+	Group,
+	Box3,
+	Sphere,
+	MeshStandardMaterial,
+	MeshPhysicalMaterial
+} from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import Stats from 'three/examples/jsm/libs/stats.module.js';
 import { UVGenerator } from '../src/utils/UVGenerator.js';
 import { AO_THICKNESS_SAMPLES_PER_UPDATE, AOThicknessMapGenerator } from '../src/utils/AOThicknessMapGenerator.js';
-
-function replaceAll( string, find, replace ) {
-
-	return string.split( find ).join( replace );
-
-}
-
-const meshphysical_frag_head = THREE.ShaderChunk[ 'meshphysical_frag' ].slice( 0, THREE.ShaderChunk[ 'meshphysical_frag' ].indexOf( 'void main() {' ) );
-const meshphysical_frag_body = THREE.ShaderChunk[ 'meshphysical_frag' ].slice( THREE.ShaderChunk[ 'meshphysical_frag' ].indexOf( 'void main() {' ) );
-
-const SubsurfaceScatteringShader = {
-
-	name: 'SubsurfaceScatteringShader',
-
-	uniforms: THREE.UniformsUtils.merge( [
-		THREE.ShaderLib[ 'physical' ].uniforms,
-		{
-			'thicknessMap': { value: null },
-			'thicknessColor': { value: new THREE.Color( 0xffffff ) },
-			'thicknessDistortion': { value: 0.1 },
-			'thicknessAmbient': { value: 0.0 },
-			'thicknessAttenuation': { value: 0.1 },
-			'thicknessPower': { value: 2.0 },
-			'thicknessScale': { value: 10.0 },
-			'subsurfaceScattering': { value: 0.1 },
-			'subsurfaceRadius': { value: 0.5 },
-			'subsurfaceBrightness': { value: 0.3 },
-			'subsurfaceSaturation': { value: 0.6 },
-		}
-
-	] ),
-
-	vertexShader: [
-		'#define USE_UV',
-		'#define USE_UV2',
-		'#define USE_AOMAP',
-		'#define AOMAP_UV uv2',
-		'attribute vec2 uv2;',
-		THREE.ShaderChunk[ 'meshphysical_vert' ]
-	].join( '\n' ),
-
-	fragmentShader: [
-		'#define USE_UV',
-		'#define USE_UV2',
-		'#define USE_AOMAP',
-		'#define AOMAP_UV uv2;',
-		'#define SUBSURFACE',
-
-		meshphysical_frag_head,
-
-		'uniform sampler2D thicknessMap;',
-		'uniform float thicknessPower;',
-		'uniform float thicknessScale;',
-		'uniform float thicknessDistortion;',
-		'uniform float thicknessAmbient;',
-		'uniform float thicknessAttenuation;',
-		'uniform vec3 thicknessColor;',
-		'uniform float subsurfaceRadius;',
-		'uniform float subsurfaceScattering;',
-		'uniform float subsurfaceBrightness;',
-		'uniform float subsurfaceSaturation;',
-
-		'vec3 adjustBrightnessAndSaturation(vec3 color, float brightness, float saturation) {',
-		'  vec3 average = vec3((color.r + color.g + color.b) / 3.0);',
-		'  if (saturation > 0.0) {',
-		'    color += (average - color) * (1.0 - 1.0 / (1.001 - saturation));',
-		'  } else {',
-		'    color += (average - color) * (-saturation);',
-		'  }',
-		'  color += brightness;',
-		'  color = clamp(color, 0.0, 1.0);',
-		'  return color;',
-		'}',
-
-		'vec3 LightingSubsurface(vec3 lightDir, vec3 normalWS, vec3 subsurfaceColor, float subsurfaceRadius) {',
-		'    float NdotL = dot(normalWS, lightDir);',
-		'    float alpha = subsurfaceRadius;',
-		'    float theta_m = acos(-alpha);',
-		'    float theta = max(0.0, NdotL + alpha) - alpha;',
-		'    float normalization_jgt = (2.0 + alpha) / (2.0 * (1.0 + alpha));',
-		'    float wrapped_jgt = pow(((theta + alpha) / (1.0 + alpha)), 1.0 + alpha) * normalization_jgt;',
-		'    return subsurfaceColor * wrapped_jgt;',
-		'}',
-
-		'void RE_Direct_Scattering(const in IncidentLight directLight, const in vec2 uv, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, inout ReflectedLight reflectedLight, const in PhysicalMaterial material) {',
-		' vec3 thickness = thicknessColor * (1.0 - texture2D(thicknessMap, uv).g);',
-		' vec3 scatteringHalf = normalize(directLight.direction + (geometryNormal * thicknessDistortion));',
-		' float scatteringDot = pow(saturate(dot(geometryViewDir, -scatteringHalf)), thicknessPower) * thicknessScale;',
-		' vec3 scatteringIllu = (scatteringDot + thicknessAmbient) * thickness;',
-		' vec3 subsurfaceColor = adjustBrightnessAndSaturation(material.diffuseColor, subsurfaceBrightness, subsurfaceSaturation);',
-		' vec3 translucency = scatteringIllu * thicknessAttenuation * subsurfaceColor;',
-		' vec3 subsurfaceContribution = LightingSubsurface(directLight.direction, geometryNormal, subsurfaceColor, subsurfaceRadius);',
-		' reflectedLight.directDiffuse += translucency;',
-		' reflectedLight.directDiffuse = mix(reflectedLight.directDiffuse, subsurfaceContribution, subsurfaceScattering);',
-		'}',
-
-		meshphysical_frag_body.replace( '#include <lights_fragment_begin>',
-
-			replaceAll(
-				THREE.ShaderChunk[ 'lights_fragment_begin' ],
-				'RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );',
-				[
-					'RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );',
-
-					'#if defined( SUBSURFACE ) && defined( USE_UV )',
-					' if (subsurfaceScattering > 0.0) { RE_Direct_Scattering(directLight, vAoMapUv, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, reflectedLight, material); }',
-					'#endif',
-				].join( '\n' )
-			),
-
-		)
-
-	].join( '\n' ),
-
-};
 
 let renderer, camera, scene, stats;
 let statusEl, totalSamples = 0;
@@ -130,53 +32,24 @@ const MAX_SAMPLES = 1000;
 
 init();
 
-function initMaterial( aoThicknessTexture ) {
-
-	const shader = SubsurfaceScatteringShader;
-	const uniforms = THREE.UniformsUtils.clone( shader.uniforms );
-
-	uniforms[ 'diffuse' ].value = new THREE.Vector3( 1.0, 0.2, 0.2 );
-
-	uniforms[ 'thicknessMap' ].value = aoThicknessTexture;
-	uniforms[ 'thicknessColor' ].value = new THREE.Vector3( 0.5, 0.3, 0.0 );
-	uniforms[ 'thicknessDistortion' ].value = 0.1;
-	uniforms[ 'thicknessAmbient' ].value = 0.4;
-	uniforms[ 'thicknessAttenuation' ].value = 0.8;
-	uniforms[ 'thicknessPower' ].value = 2.0;
-	uniforms[ 'thicknessScale' ].value = 16.0;
-	uniforms[ 'subsurfaceScattering' ].value = 0.1;
-	uniforms[ 'subsurfaceRadius' ].value = 0.5;
-	uniforms[ 'subsurfaceBrightness' ].value = 0.3;
-	uniforms[ 'subsurfaceSaturation' ].value = 0.6;
-	uniforms[ 'aoMap' ].value = aoThicknessTexture;
-
-	return new THREE.ShaderMaterial( {
-		uniforms: uniforms,
-		vertexShader: shader.vertexShader,
-		fragmentShader: shader.fragmentShader,
-		lights: true
-	} );
-
-}
-
 async function init() {
 
 	// initialize renderer
-	renderer = new THREE.WebGLRenderer( { antialias: true } );
+	renderer = new WebGLRenderer( { antialias: true } );
 	document.body.appendChild( renderer.domElement );
 
-	camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 200 );
+	camera = new PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 200 );
 	camera.position.set( - 4, 2, 3 );
 
-	scene = new THREE.Scene();
+	scene = new Scene();
 
-	const light1 = new THREE.PointLight( 0xaaaaa, 20, 100 );
+	const light1 = new PointLight( 0xaaaaa, 20, 100 );
 	light1.position.set( 3, 3, 3 );
 
-	const light2 = new THREE.PointLight( 0xaaaaaa, 20, 100 );
+	const light2 = new PointLight( 0xaaaaaa, 20, 100 );
 	light2.position.set( - 3, - 3, - 3 );
 
-	const ambientLight = new THREE.AmbientLight( 0xffffff, 2.75 );
+	const ambientLight = new AmbientLight( 0xffffff, 2.75 );
 	scene.add( ambientLight );
 
 	scene.add( light1 );
@@ -192,13 +65,13 @@ async function init() {
 
 	const geometriesToBake = [];
 
-	const aoTarget = new THREE.WebGLRenderTarget( AO_THICKNESS_TEXTURE_SIZE, AO_THICKNESS_TEXTURE_SIZE, {
-		type: THREE.FloatType,
-		colorSpace: THREE.LinearSRGBColorSpace,
+	const aoTarget = new WebGLRenderTarget( AO_THICKNESS_TEXTURE_SIZE, AO_THICKNESS_TEXTURE_SIZE, {
+		type: FloatType,
+		colorSpace: LinearSRGBColorSpace,
 		generateMipmaps: true,
-		minFilter: THREE.NearestMipMapNearestFilter,
-		magFilter: THREE.NearestFilter,
-		format: THREE.RGBAFormat,
+		// minFilter: NearestMipMapNearestFilter,
+		// magFilter: NearestFilter,
+		format: RGBAFormat,
 	} );
 
 	aoGenerator = new AOThicknessMapGenerator( renderer );
@@ -207,21 +80,27 @@ async function init() {
 	aoGenerator.aoRadius = 2;
 	aoGenerator.thicknessRadius = 0.5;
 	aoTexture = aoTarget.texture;
-	const aoMaterial = initMaterial( aoTexture );
-	aoMaterial.uniforms.aoMap.value = aoMaterial.uniforms.thicknessMap.value = aoTexture;
+	aoTexture.channel = 2;
+
+	const aoMaterial = new MeshPhysicalMaterial( {
+
+		aoMap: aoTexture,
+		thicknessMap: aoTexture,
+
+	} );
 
 	const gltfPromise = new GLTFLoader()
 		.setMeshoptDecoder( MeshoptDecoder )
 		.loadAsync( url )
 		.then( async gltf => {
 
-			const group = new THREE.Group();
+			const group = new Group();
 
 			// scale the scene to a reasonable size
-			const box = new THREE.Box3();
+			const box = new Box3();
 			box.setFromObject( gltf.scene );
 
-			const sphere = new THREE.Sphere();
+			const sphere = new Sphere();
 			box.getBoundingSphere( sphere );
 
 			gltf.scene.scale.setScalar( 2.5 / sphere.radius );

--- a/src/materials/surface/AOThicknessMaterial.js
+++ b/src/materials/surface/AOThicknessMaterial.js
@@ -47,7 +47,7 @@ export class AOThicknessMaterial extends MaterialBase {
 
 		super( {
 			defines: {
-				SAMPLES: 10,
+				SAMPLES: 1,
 				MATERIAL_PIXELS: MATERIAL_PIXELS
 			},
 

--- a/src/utils/AOThicknessMapGenerator.js
+++ b/src/utils/AOThicknessMapGenerator.js
@@ -7,7 +7,7 @@ import { MipFlooder } from './MipFlooder.js';
 import { UVEdgeExpander } from './UVEdgeExpander.js';
 import { PathTracingSceneGenerator } from '../core/PathTracingSceneGenerator.js';
 
-export const AO_THICKNESS_SAMPLES_PER_UPDATE = 10;
+export const AO_THICKNESS_SAMPLES_PER_UPDATE = 1;
 
 export class AOThicknessMapGenerator {
 

--- a/src/utils/UVGenerator.js
+++ b/src/utils/UVGenerator.js
@@ -11,7 +11,7 @@ const AddMeshStatus = {
 
 export class UVGenerator {
 
-	constructor( wasmPath = '../../node_modules/@gfodor/xatlas-web/dist/xatlas-web.wasm' ) {
+	constructor( wasmPath = new URL( '../../node_modules/@gfodor/xatlas-web/dist/xatlas-web.wasm', import.meta.url ) ) {
 
 		this._module = null;
 		this._wasmPath = wasmPath;


### PR DESCRIPTION
Hey @gfodor - I made a few changes to the AO Bake example to simplify it and show the generated maps more clearly. Here's a list of the main changes:

- Remove SSS shader
- Add a toggle for transmissive / opaque materials
- Add a background map so the transmission is more clear
- Add a toggle to display the full map
- Change the shader to generate 1 sample at a time rather than 10 to avoid locking the screen.
- Use bilinear filtering on the AO and thickness map.

I think this shows a bit why the aviator helmet isn't so well-suited for thickness maps, as well. The leather bit and metal placard are extremely thin and three.js doesn't support overlapping transmissive materials

**AO Map**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/551a6d5e-6e0f-4ec9-9147-647287249cac">

**Thickness Map**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/44812803-aec9-47eb-bbe8-e1a16ffbfb71"> <img width="300" alt="image" src="https://github.com/user-attachments/assets/b2322fe4-6921-4cb3-9ae0-fb6481fb27ad">

**Map Display**

<img width="500" alt="image" src="https://github.com/user-attachments/assets/afdd66f0-f2e4-40a7-b935-436b37c779e0">

**Other Thoughts**
One thing I noticed are these black pixels at some hard edges in the model:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/981826ba-9f3b-40f1-88c8-9bdc0e058282"> 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/dd5e6b25-6d4d-4179-b542-6db17be060a9">

I'll have to look into why this is happening a bit more but it's possible this is due to the ray origin not being offset from the surface far enough. The maps would probably also benefit from some sub-pixel jitter so the samples better represent the texel coverage on the surface of the triangle.